### PR TITLE
Added logout

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,3 +10,4 @@ class Config():
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(days=7).total_seconds()
     DEBUG= True
     SECRET_KEY =  urandom(32)
+    LOGOUT_URIS = ['http://localhost:5000/logout']

--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -11,8 +11,15 @@ def create_app():
     CLIENT1 = app.config['CLIENT1']
     SECRET = app.config['SECRET']
     PROVIDER_NAME1 = app.config['PROVIDER_NAME1']
+    LOGOUT_URIS = app.config['LOGOUT_URIS']
 
-    PROVIDER_CONFIG = ProviderConfiguration(issuer=ISSUER1, client_metadata=ClientMetadata(CLIENT1, SECRET))
+    PROVIDER_CONFIG = ProviderConfiguration(
+        issuer=ISSUER1,
+        client_metadata=ClientMetadata(
+            CLIENT1, SECRET,
+            post_logout_redirect_uris=LOGOUT_URIS
+        )
+    )
 
     auth = OIDCAuthentication({PROVIDER_NAME1: PROVIDER_CONFIG})
     auth.init_app(app)

--- a/flask_app/main_routes.py
+++ b/flask_app/main_routes.py
@@ -23,3 +23,9 @@ def about():
         return f"things about you: {info}"
     except:
         return f"this user is a mystery"
+
+
+@main_bp.route('/logout')
+@auth.oidc_logout
+def logout_view():
+    return "logged out"


### PR DESCRIPTION
Logout is supported with blueprints (https://github.com/zamzterz/Flask-pyoidc/issues/48). I've tested and added a route to `main_routes.py`.

Thanks for making the blueprints example : )